### PR TITLE
PHPテキスト教材詳細ページの実装 #26

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'turbolinks', '~> 5'
 gem 'jbuilder', '~> 2.7'
 gem 'bootsnap', '>= 1.4.4', require: false
 gem 'redcarpet'
+gem 'coderay'
 
 gem 'devise'
 gem 'rails-i18n', '~> 6.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,6 +209,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.4.4)
   byebug
+  coderay
   devise
   devise-i18n
   jbuilder (~> 2.7)

--- a/app/controllers/php_texts_controller.rb
+++ b/app/controllers/php_texts_controller.rb
@@ -2,4 +2,8 @@ class PhpTextsController < ApplicationController
   def index
     @php_texts = Text.where(genre: "Php")
   end
+
+  def show
+    @php_text = Text.find(params[:id])
+  end
 end

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -7,7 +7,11 @@ module MarkdownHelper
   private
 
   def html_renderer
-    Redcarpet::Render::HTML
+    ::Coderayify.new(
+      filter_html: true,
+      hard_wrap: true,
+      link_attributes: { rel: "nofollow", target: "_blank" },
+    )
   end
 
   def markdown_extensions

--- a/app/views/php_texts/index.html.erb
+++ b/app/views/php_texts/index.html.erb
@@ -5,7 +5,7 @@
   <div>
     <div>
       <% @php_texts.each do |php_text| %>
-        <%= link_to "#", target: :_blank do %>
+        <%= link_to php_text_path(php_text.id), target: :_blank do %>
           <%= image_tag 'default.jpg' %>
           <p><%= php_text.title %></p>
           <p>【PHP】</p>

--- a/app/views/php_texts/show.html.erb
+++ b/app/views/php_texts/show.html.erb
@@ -1,0 +1,6 @@
+<div>
+  <div>
+    <h3><%= @php_text.title %></h3>
+    <%= markdown(@php_text.content) %>
+  </div>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,7 +25,7 @@ module TeamProject
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
     config.i18n.default_locale = :ja
-    config.time_zone = 'Asia/Tokyo'
+    config.time_zone = "Asia/Tokyo"
     # lib/autoloads ディレクトリ配下のファイルを読み込む
     config.autoload_paths << Rails.root.join("lib/autoloads")
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,6 @@ Rails.application.routes.draw do
   devise_for :users
   root "texts#index"
   resources :texts
-
   resources :lines, only: [:index, :show]
-  resources :php_texts, only: [:index]
+  resources :php_texts, only: [:index, :show]
 end

--- a/lib/autoloads/coderayify.rb
+++ b/lib/autoloads/coderayify.rb
@@ -1,0 +1,33 @@
+class Coderayify < Redcarpet::Render::HTML
+  def block_code(code, language)
+    ext = retrieve_extension(language)
+
+    lang = case ext
+      when "rb"
+        :ruby
+      when "yml"
+        :yaml
+      else
+        ext.to_sym
+      end
+    CodeRay.scan(code, lang).div
+  end
+
+  private
+
+  # 拡張子を取得するメソッド
+  def retrieve_extension(language)
+    if language.blank?
+      # コードブロックの開始宣言で「```」の後に拡張子が与えられていない場合は md 形式とみなす
+      "md"
+    elsif language.include?(":")
+      # コードブロックの開始宣言が「```rb:sample.rb」の場合は rb 形式とみなす
+      language.split(":")[0]
+    elsif language.include?(".")
+      # コードブロックの開始宣言が「```sample.rb」の場合は rb 形式とみなす
+      language.split(".")[-1]
+    else
+      language
+    end
+  end
+end


### PR DESCRIPTION
## issue #26 

close #26 

## 実装内容

- シンタックスハイライトを実装
  - coderayを追加
  - markdown_helper.rbを修正
  - autoloads/coderayify.rbを作成

- PHPテキスト教材詳細ページの実装
  - php_texts_controller.rbにshowアクションを追加
  - PHPテキスト教材詳細ページのshow.html.erbを作成
  - index.html.erbからshow.html.erbへのリンクを修正
  - routes.rbにphp_texts_controllerのshowアクションへのrouteを設定

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認

## 備考（必要があれば）

- 詳細ページのデザインは別タスクで行う予定のため、対象外となっております。詳細ページのcontroller,view,route,coderayの追加に伴う初期設定のレビューをお願いいたします。
- config/application.rbの''が""になっている件に関しましては、rufoが動いてしまったためです。必要であれば修正いたします。
